### PR TITLE
Fix cabal bulid for c flies

### DIFF
--- a/autorecorder/autorecorder.cabal
+++ b/autorecorder/autorecorder.cabal
@@ -14,13 +14,13 @@ copyright:      Copyright (c) 2022 Tom Sydney Kerckhove
 license:        MIT
 build-type:     Simple
 
-source-repository head
-  type: git
-  location: https://github.com/NorfairKing/autorecorder
-
 extra-source-files:
     cbits/window_size.h
     cbits/window_size.c
+
+source-repository head
+  type: git
+  location: https://github.com/NorfairKing/autorecorder
 
 library
   exposed-modules:

--- a/autorecorder/autorecorder.cabal
+++ b/autorecorder/autorecorder.cabal
@@ -18,6 +18,10 @@ source-repository head
   type: git
   location: https://github.com/NorfairKing/autorecorder
 
+extra-source-files:
+    cbits/window_size.h
+    cbits/window_size.c
+
 library
   exposed-modules:
       AutoRecorder
@@ -35,8 +39,11 @@ library
       Paths_autorecorder
   hs-source-dirs:
       src
-  c-sources:
+  include-dirs:
+      cbits
+  includes:
       cbits/window_size.h
+  c-sources:
       cbits/window_size.c
   build-depends:
       aeson


### PR DESCRIPTION
Build fails for me with error:

```
Warning: the following files would be used as linker inputs, but linking is not being done: cbits/window_size.h
ghc-9.4.5: no input files
```

Fixed cabal. I do not know how hpack works, so did not touch it.

My env:

> cabal-install version 3.10.1.0
> ghc-9.4.5