### PR TITLE
WaitForOutput POC

### DIFF
--- a/autorecorder/autorecorder.cabal
+++ b/autorecorder/autorecorder.cabal
@@ -47,6 +47,7 @@ library
       cbits/window_size.c
   build-depends:
       aeson
+    , regex-posix
     , async
     , autodocodec
     , autodocodec-yaml
@@ -69,6 +70,7 @@ library
     , unliftio
     , yaml
   default-language: Haskell2010
+  default-extensions: PartialTypeSignatures
 
 executable autorecorder
   main-is: Main.hs

--- a/autorecorder/autorecorder.cabal
+++ b/autorecorder/autorecorder.cabal
@@ -14,13 +14,13 @@ copyright:      Copyright (c) 2022 Tom Sydney Kerckhove
 license:        MIT
 build-type:     Simple
 
-source-repository head
-  type: git
-  location: https://github.com/NorfairKing/autorecorder
-
 extra-source-files:
     cbits/window_size.h
     cbits/window_size.c
+
+source-repository head
+  type: git
+  location: https://github.com/NorfairKing/autorecorder
 
 library
   exposed-modules:

--- a/autorecorder/autorecorder.cabal
+++ b/autorecorder/autorecorder.cabal
@@ -18,6 +18,10 @@ source-repository head
   type: git
   location: https://github.com/NorfairKing/autorecorder
 
+extra-source-files:
+    cbits/window_size.h
+    cbits/window_size.c
+
 library
   exposed-modules:
       AutoRecorder
@@ -35,8 +39,11 @@ library
       Paths_autorecorder
   hs-source-dirs:
       src
-  c-sources:
+  include-dirs:
+      cbits
+  includes:
       cbits/window_size.h
+  c-sources:
       cbits/window_size.c
   build-depends:
       aeson

--- a/autorecorder/src/AutoRecorder/Commands/Record.hs
+++ b/autorecorder/src/AutoRecorder/Commands/Record.hs
@@ -142,7 +142,7 @@ runASCIInema rs@Settings {..} specFilePath spec@ASCIInemaSpec {..} = do
                       [SendInput "exit\r" | isNothing asciinemaCommand],
                       [Wait 500]
                     ]
-            let inSender = runConduit $ inputWriter specFilePath settingOutputView settingSpeed settingMistakes tAttributes tMasterHandle commands
+            let inSender = runConduit $ inputWriter specFilePath settingOutputView settingSpeed settingMistakes tAttributes tMasterHandle outVar commands
             let outReader = runConduit $ outputConduit settingOutputView outVar tMasterHandle
             mExitedNormally <-
               timeout (asciinemaTimeout * 1000 * 1000) $

--- a/autorecorder/src/AutoRecorder/Output.hs
+++ b/autorecorder/src/AutoRecorder/Output.hs
@@ -3,6 +3,7 @@
 module AutoRecorder.Output where
 
 import Conduit
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as SB
@@ -29,7 +30,9 @@ outputConduit ov outVar h =
     .| outputSink outVar
 
 outputSink :: MonadIO m => TVar [(UTCTime, ByteString)] -> ConduitT (UTCTime, ByteString) void m ()
-outputSink outVar = awaitForever $ \t -> liftIO $ atomically $ modifyTVar' outVar (t :)
+outputSink outVar = awaitForever $ \t -> liftIO $ do
+  atomically $ modifyTVar' outVar (t :)
+  threadDelay 10
 
 outputTimerConduit :: MonadIO m => ConduitT i (UTCTime, i) m ()
 outputTimerConduit = C.mapM $ \i -> (,) <$> liftIO getCurrentTime <*> pure i

--- a/autorecorder/src/AutoRecorder/Spec.hs
+++ b/autorecorder/src/AutoRecorder/Spec.hs
@@ -40,6 +40,7 @@ instance HasCodec ASCIInemaSpec where
 
 data ASCIInemaCommand
   = Wait Word -- Milliseconds
+  | WaitForOutput String -- TODO: regexp
   | SendInput String
   | Type String Word -- Milliseconds
   deriving (Show, Eq)
@@ -50,6 +51,8 @@ instance HasCodec ASCIInemaCommand where
       $ eitherCodec
         (object "Wait" $ requiredField "wait" "How long to wait (in milliseconds)")
       $ eitherCodec
+        (object "WaitForOutput" $ requiredField "waitForOutput" "TODO")
+      $ eitherCodec
         (object "SendInput" $ requiredField "send" "The input to send")
         ( object "Type" $
             (,)
@@ -59,12 +62,14 @@ instance HasCodec ASCIInemaCommand where
     where
       f = \case
         Left w -> Wait w
-        Right (Left s) -> SendInput s
-        Right (Right (s, w)) -> Type s w
+        Right (Left s) -> WaitForOutput s
+        Right (Right (Left s)) -> SendInput s
+        Right (Right (Right (s, w))) -> Type s w
       g = \case
         Wait w -> Left w
-        SendInput s -> Right (Left s)
-        Type s w -> Right (Right (s, w))
+        WaitForOutput s -> Right (Left s)
+        SendInput s -> Right (Right (Left s))
+        Type s w -> Right (Right (Right (s, w)))
 
 commandDelay :: ASCIInemaCommand -> Word
 commandDelay = \case


### PR DESCRIPTION
This is awful in multiple ways, but it works.

Essentially we need to duplicate master handle to read from it twice. hDuplicate does work for me and hDuplicateTo will probably break pseudo-terminal internals.

So proper solution, I believe, would be to change Conduit arch to make Input dependent of Output or something like that.

Closes #5 